### PR TITLE
[APM-CI][.NET] Support build from source code and avoid fetching from nuget

### DIFF
--- a/docker/dotnet/NuGet.Config
+++ b/docker/dotnet/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+ <packageSources>
+    <add key="local" value="/src/local-packages" />
+ </packageSources>
+</configuration>

--- a/docker/dotnet/aspnetcore/appsettings.json
+++ b/docker/dotnet/aspnetcore/appsettings.json
@@ -4,5 +4,10 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ElasticApm":
+    {
+      "LogLevel":  "Debug",
+      "TransactionSampleRate": 1.0
+    }
 }

--- a/docker/dotnet/run.sh
+++ b/docker/dotnet/run.sh
@@ -5,11 +5,14 @@ CSPROJ="TestAspNetCoreApp.csproj"
 if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   git clone https://github.com/${DOTNET_AGENT_REPO}.git /src/dotnet-agent -b ${DOTNET_AGENT_BRANCH}
   cd /src/dotnet-agent
+  ### Otherwise: /usr/share/dotnet/sdk/2.2.203/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/dotnet-agent/ElasticApmAgent.sln]
+  mkdir /src/local-packages
   dotnet restore
-  dotnet publish -c Release -o build
+  dotnet pack -c Release -o /src/local-packages
 
   cd /src/aspnetcore
-  sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/dotnet-agent/src/Elastic.Apm.All/build;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
+  mv ../NuGet.Config .
+  sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
   DOTNET_AGENT_VERSION=$(cat /src/dotnet-agent/src/Elastic.Apm.All/Elastic.Apm.All.csproj | grep 'PackageVersion' | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
   dotnet add package Elastic.Apm.All -v ${DOTNET_AGENT_VERSION}
 fi

--- a/docker/opbeans/dotnet/NuGet.Config
+++ b/docker/opbeans/dotnet/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+ <packageSources>
+    <add key="local" value="/src/local-packages" />
+ </packageSources>
+</configuration>

--- a/docker/opbeans/dotnet/run.sh
+++ b/docker/opbeans/dotnet/run.sh
@@ -1,21 +1,25 @@
 #!/usr/bin/env bash
 set -x
 git clone https://github.com/${OPBEANS_DOTNET_REPO}.git /src/opbeans-dotnet -b ${OPBEANS_DOTNET_BRANCH}
+CSPROJ="opbeans-dotnet.csproj"
 
 if [ -z "${DOTNET_AGENT_VERSION}" ] ; then
   git clone https://github.com/${DOTNET_AGENT_REPO}.git /src/dotnet-agent -b ${DOTNET_AGENT_BRANCH}
   cd /src/dotnet-agent
+  ### Otherwise: /usr/share/dotnet/sdk/2.2.203/NuGet.targets(119,5): error : The local source '/src/local-packages' doesn't exist. [/src/dotnet-agent/ElasticApmAgent.sln]
+  mkdir /src/local-packages
   dotnet restore
-  dotnet publish -c Release -o build
+  dotnet pack -c Release -o /src/local-packages
 
   cd /src/opbeans-dotnet/opbeans-dotnet
-  sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/dotnet-agent/src/Elastic.Apm.All/build;https://api.nuget.org/v3/index.json</RestoreSources>#' opbeans-dotnet.csproj
+  mv ../NuGet.Config .
+  sed -ibck 's#<PropertyGroup>#<PropertyGroup><RestoreSources>$(RestoreSources);/src/local-packages;https://api.nuget.org/v3/index.json</RestoreSources>#' ${CSPROJ}
   DOTNET_AGENT_VERSION=$(cat /src/dotnet-agent/src/Elastic.Apm.All/Elastic.Apm.All.csproj | grep 'PackageVersion' | sed 's#<.*>\(.*\)<.*>#\1#' | tr -d " ")
   dotnet add package Elastic.Apm.All -v ${DOTNET_AGENT_VERSION}
 fi
 
 cd /src/opbeans-dotnet/opbeans-dotnet
 # This is the way to manipulate the csproj with the version of the dotnet agent to be used
-sed -ibck "s#\(<PackageReference Include=\"Elastic\.Apm\.All\" Version=\)\"\(.*\)\"#\1\"${DOTNET_AGENT_VERSION}\"#" opbeans-dotnet.csproj
+sed -ibck "s#\(<PackageReference Include=\"Elastic\.Apm\.All\" Version=\)\"\(.*\)\"#\1\"${DOTNET_AGENT_VERSION}\"#" ${CSPROJ}
 dotnet restore
 dotnet publish -c Release -o build


### PR DESCRIPTION
Use the reference git repo:
- https://github.com/dasMulli/LocalNupkgExample

As suggested in the stackoverflow:
- https://stackoverflow.com/questions/43400069/dotnet-add-package-with-local-package-file

## Test Cases
- `docker build --build-arg DOTNET_AGENT_REPO=gregkalapos/apm-agent-dotnet --build-arg DOTNET_AGENT_BRANCH=FixConcurrentRequests --tag test .`
- `docker run -e ELASTIC_APM_SERVER_URLS=http://apm-server:8200 --network apm-integration-testing --rm -ti -p 18080:8100 test:latest`
```
[2019-05-02 02:52:34][Debug] - {ApmMiddleware} Incoming request. Starting Trace.
[2019-05-02 02:52:34][Debug] - {Tracer} Starting Transaction{Id: dce919c28eb6fc4c, TraceId: c5216f03cfbe7ad17e2c078b7d43497b, ParentId: null, Name: GET /foo, Type: request, IsSampled: True}
[2019-05-02 02:52:34][Debug] - {Transaction} Starting Span{Id: 7914b85220f4cc67, TransactionId: dce919c28eb6fc4c, ParentId: dce919c28eb6fc4c, TraceId: c5216f03cfbe7ad17e2c078b7d43497b, Name: foo, Type: app, IsSampled: True}
[2019-05-02 02:52:34][Debug] - {Span} Ending Span{Id: 7914b85220f4cc67, TransactionId: dce919c28eb6fc4c, ParentId: dce919c28eb6fc4c, TraceId: c5216f03cfbe7ad17e2c078b7d43497b, Name: foo, Type: app, IsSampled: True}
[2019-05-02 02:52:34][Debug] - {PayloadSenderV2} Transaction added to the queue, Transaction{Id: dce919c28eb6fc4c, TraceId: c5216f03cfbe7ad17e2c078b7d43497b, ParentId: null, Name: GET /foo, Type: request, IsSampled: True}
[2019-05-02 02:52:34][Debug] - {Transaction} Ending Transaction{Id: dce919c28eb6fc4c, TraceId: c5216f03cfbe7ad17e2c078b7d43497b, ParentId: null, Name: GET /foo, Type: request, IsSampled: True}
[2019-05-02 02:52:34][Debug] - {DiagnosticInitializer} Subscribed Elastic.Apm.DiagnosticListeners.HttpDiagnosticListenerCoreImpl to `HttpHandlerDiagnosticListener' events source
[2019-05-02 02:52:34][Debug] - {PayloadSenderV2} Sent items to server: 
Span{Id: 7914b85220f4cc67, TransactionId: dce919c28eb6fc4c, ParentId: dce919c28eb6fc4c, TraceId: c5216f03cfbe7ad17e2c078b7d43497b, Name: foo, Type: app, IsSampled: True},
Transaction{Id: dce919c28eb6fc4c, TraceId: c5216f03cfbe7ad17e2c078b7d43497b, ParentId: null, Name: GET /foo, Type: request, IsSampled: True}
```
